### PR TITLE
Add service tests and env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+APP_JWT_SECRET=your-32-char-secret-key-here-1234
+APP_JWT_EXPIRATION=3600000

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,5 +10,5 @@ spring:
 
 app:
   jwt:
-    secret: eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJDbGluaWMiLCJzdWIiOiJsdWlzbXpmIiwiYXV0aG9yaXRpZXMiOlsiUk9MRV9VU0VSIl0sImlhdCI6MTczNDExMTcwOCwiZXhwIjoxNzM0MTI2MTA4fQ.oAzRuaowrvoMCGM06s9LIgLtxVg1Bvuu1RE8b6AyDD4
-    expiration: 3600000
+    secret: ${APP_JWT_SECRET:01234567890123456789012345678901}
+    expiration: ${APP_JWT_EXPIRATION:3600000}

--- a/src/test/java/me/quadradev/auth/application/command/UpdateUserStatusCommandHandlerTest.java
+++ b/src/test/java/me/quadradev/auth/application/command/UpdateUserStatusCommandHandlerTest.java
@@ -1,0 +1,38 @@
+package me.quadradev.auth.application.command;
+
+import me.quadradev.auth.application.command.user.UpdateUserStatusCommand;
+import me.quadradev.auth.application.command.user.UpdateUserStatusCommandHandler;
+import me.quadradev.auth.common.error.ResourceNotFoundException;
+import me.quadradev.auth.domain.user.User;
+import me.quadradev.auth.domain.user.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class UpdateUserStatusCommandHandlerTest {
+
+    @Autowired
+    private UpdateUserStatusCommandHandler handler;
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    void handleUpdatesStatus() {
+        User user = userRepository.save(User.builder().email("status@example.com").password("pwd").status(0).build());
+        UpdateUserStatusCommand cmd = new UpdateUserStatusCommand(user.getId(), 1);
+        User updated = handler.handle(cmd);
+        assertEquals(1, updated.getStatus());
+        assertEquals(1, userRepository.findById(user.getId()).orElseThrow().getStatus());
+    }
+
+    @Test
+    void handleThrowsForMissingUser() {
+        UpdateUserStatusCommand cmd = new UpdateUserStatusCommand(999L, 1);
+        assertThrows(ResourceNotFoundException.class, () -> handler.handle(cmd));
+    }
+}

--- a/src/test/java/me/quadradev/auth/application/query/GetUserByEmailQueryHandlerTest.java
+++ b/src/test/java/me/quadradev/auth/application/query/GetUserByEmailQueryHandlerTest.java
@@ -1,0 +1,35 @@
+package me.quadradev.auth.application.query;
+
+import me.quadradev.auth.application.query.user.GetUserByEmailQuery;
+import me.quadradev.auth.application.query.user.GetUserByEmailQueryHandler;
+import me.quadradev.auth.common.error.ResourceNotFoundException;
+import me.quadradev.auth.domain.user.User;
+import me.quadradev.auth.domain.user.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class GetUserByEmailQueryHandlerTest {
+
+    @Autowired
+    private GetUserByEmailQueryHandler handler;
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    void handleReturnsUser() {
+        userRepository.save(User.builder().email("byemail@example.com").password("pwd").status(1).build());
+        User found = handler.handle(new GetUserByEmailQuery("byemail@example.com"));
+        assertEquals("byemail@example.com", found.getEmail());
+    }
+
+    @Test
+    void handleThrowsForMissingEmail() {
+        assertThrows(ResourceNotFoundException.class, () -> handler.handle(new GetUserByEmailQuery("missing@example.com")));
+    }
+}

--- a/src/test/java/me/quadradev/auth/application/query/GetUserByIdQueryHandlerTest.java
+++ b/src/test/java/me/quadradev/auth/application/query/GetUserByIdQueryHandlerTest.java
@@ -1,0 +1,35 @@
+package me.quadradev.auth.application.query;
+
+import me.quadradev.auth.application.query.user.GetUserByIdQuery;
+import me.quadradev.auth.application.query.user.GetUserByIdQueryHandler;
+import me.quadradev.auth.common.error.ResourceNotFoundException;
+import me.quadradev.auth.domain.user.User;
+import me.quadradev.auth.domain.user.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class GetUserByIdQueryHandlerTest {
+
+    @Autowired
+    private GetUserByIdQueryHandler handler;
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    void handleReturnsUser() {
+        User saved = userRepository.save(User.builder().email("byid@example.com").password("pwd").status(1).build());
+        User found = handler.handle(new GetUserByIdQuery(saved.getId()));
+        assertEquals("byid@example.com", found.getEmail());
+    }
+
+    @Test
+    void handleThrowsForMissingUser() {
+        assertThrows(ResourceNotFoundException.class, () -> handler.handle(new GetUserByIdQuery(999L)));
+    }
+}

--- a/src/test/java/me/quadradev/auth/application/query/ListUsersQueryHandlerTest.java
+++ b/src/test/java/me/quadradev/auth/application/query/ListUsersQueryHandlerTest.java
@@ -1,0 +1,33 @@
+package me.quadradev.auth.application.query;
+
+import me.quadradev.auth.application.query.user.ListUsersQuery;
+import me.quadradev.auth.application.query.user.ListUsersQueryHandler;
+import me.quadradev.auth.domain.user.User;
+import me.quadradev.auth.domain.user.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class ListUsersQueryHandlerTest {
+
+    @Autowired
+    private ListUsersQueryHandler handler;
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    void handleReturnsPageOfUsers() {
+        for (int i = 0; i < 3; i++) {
+            userRepository.save(User.builder().email("user" + i + "@example.com").password("pwd").status(1).build());
+        }
+        Page<User> page = handler.handle(new ListUsersQuery(0, 2));
+        assertEquals(2, page.getContent().size());
+        assertEquals(3, page.getTotalElements());
+    }
+}

--- a/src/test/java/me/quadradev/auth/infrastructure/security/JwtProviderTest.java
+++ b/src/test/java/me/quadradev/auth/infrastructure/security/JwtProviderTest.java
@@ -1,0 +1,23 @@
+package me.quadradev.auth.infrastructure.security;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class JwtProviderTest {
+
+    @Autowired
+    private JwtProvider jwtProvider;
+
+    @Test
+    void generateAndValidateToken() {
+        String token = jwtProvider.generateToken("subject", 1L, List.of("ROLE_USER"));
+        assertTrue(jwtProvider.validateToken(token));
+        assertEquals("subject", jwtProvider.getSubject(token));
+    }
+}


### PR DESCRIPTION
## Summary
- load JWT config from environment variables
- add `.env.example` for safe variable sharing
- add unit tests for query and command handlers plus JWT provider

## Testing
- `mvn -q test` *(fails: Network is unreachable and parent POM could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68a4bfd3eb588330b3f8658a22389400