### PR TITLE
Add dedicated test profile configuration

### DIFF
--- a/src/test/java/me/quadradev/auth/AbstractIntegrationTest.java
+++ b/src/test/java/me/quadradev/auth/AbstractIntegrationTest.java
@@ -8,7 +8,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers
-@ActiveProfiles("mysql")
+@ActiveProfiles("test")
 public abstract class AbstractIntegrationTest {
 
     @Container

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,14 @@
+spring:
+  datasource:
+    url: ${TEST_DB_URL:jdbc:mysql://localhost:3306/authdb?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC}
+    username: ${TEST_DB_USERNAME:user}
+    password: ${TEST_DB_PASSWORD:password}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate.dialect: org.hibernate.dialect.MySQL8Dialect
+  flyway:
+    enabled: true
+    locations: classpath:db/migration/mysql


### PR DESCRIPTION
## Summary
- add `application-test` profile for datasource, JPA, and Flyway settings used in tests
- switch integration tests to the `test` profile

## Testing
- `mvn -q test` *(fails: Network is unreachable for Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68a4caaa6f94833088b3bad797c60d29